### PR TITLE
Hide members list

### DIFF
--- a/config/backends/no-members-list.scss
+++ b/config/backends/no-members-list.scss
@@ -1,0 +1,13 @@
+@import 'colors.scss';
+
+//@import 'backends/wal.scss'
+
+$bg: $background;
+$bgDarker: mix($background, #000, 90%); // for sidebars and titlebars
+$colorUrgent: $color6; // for new messages notificatinons and the alike
+$colorAccent: $color1; // "encourages user interaction", I just copied from android colors
+$fg: $foreground; // text color
+
+div[class^='membersWrap'], div[class*=' membersWrap']{
+  display: none !important;
+}

--- a/config/backends/no-members-list.scss
+++ b/config/backends/no-members-list.scss
@@ -4,8 +4,8 @@
 
 $bg: $background;
 $bgDarker: mix($background, #000, 90%); // for sidebars and titlebars
-$colorUrgent: $color6; // for new messages notificatinons and the alike
-$colorAccent: $color1; // "encourages user interaction", I just copied from android colors
+$colorUrgent: $color3; // for new messages notificatinons and the alike
+$colorAccent: $color5; // "encourages user interaction", I just copied from android colors
 $fg: $foreground; // text color
 
 div[class^='membersWrap'], div[class*=' membersWrap']{


### PR DESCRIPTION
Since your screenshots show a hidden members list, but it wasn't hidden in the default installation of `wal-discord`, I added this myself via:
```scss
div[class^='membersWrap'], div[class*=' membersWrap']{
  display: none !important;
}
```
<sup>This way as the ID after membersWrap might change.</sup>

However, I'm not sure where best to put this. For now I put it into a backend file (this PR), which makes the change callable via `wal-discord -b no-members-list`. However, the backend file also needs to include the color variables in order not to exit with an error on `wal-discord` startup. I tried importing a default backend file as you can see as a comment in the commit, but that didn't work either.
The other option would be to put this into `master.scss` to have it on by default, or to somehow enable it via an input flag. Having it in a backend file like this also makes the use of another backend file for colors impossible, which is the originally intended purpose for these.

Let me know what you think the best option would be.